### PR TITLE
fix: Remove local content file as bc files are now supported outside the root

### DIFF
--- a/src/SQLitePCLRaw.provider.wasm/Uno.SQLitePCLRaw.provider.wasm.csproj
+++ b/src/SQLitePCLRaw.provider.wasm/Uno.SQLitePCLRaw.provider.wasm.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
 		<PackageReference Include="SQLitePCLRaw.provider.e_sqlite3" Version="2.0.3" />
-		<PackageReference Include="Uno.sqlite-wasm" Version="1.1.0-dev.16828" PrivateAssets="none" />
+		<PackageReference Include="Uno.sqlite-wasm" Version="1.1.0-dev.16828" ExcludeAssets="content" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The bootstrapper 1.4-dev and later is able to use .bc that are not located at the root of the project.